### PR TITLE
Update SwiftUISpeechToText to support different languages

### DIFF
--- a/Sources/SwiftUISpeechToText/SwiftUISpeechToText.swift
+++ b/Sources/SwiftUISpeechToText/SwiftUISpeechToText.swift
@@ -29,8 +29,8 @@ public class SpeechRecognizer: ObservableObject {
     private var task: SFSpeechRecognitionTask?
     private var recognizer: SFSpeechRecognizer? = nil
     
-    public init() {
-            recognizer = SFSpeechRecognizer()
+    public init(localeIdentifier: String = Locale.current.identifier) {
+            recognizer = SFSpeechRecognizer(locale: Locale(identifier: localeIdentifier))
             
             Task(priority: .background) {
                 do {


### PR DESCRIPTION
First of all congratulations @pandashashwat97 

Your project is very organized and easy to setup. 

This PR add the capability to pass the locale identifier to have different languages. I tested with` pt-PT`, `pt-BR` and `es-ES` and worked very well.

A extensive list of all locales is available here: https://gist.github.com/jacobbubu/1836273